### PR TITLE
[FIX] Adding missing depedency for `'nav2_waypoint_follower` package

### DIFF
--- a/_meta/installers/Dockerfile
+++ b/_meta/installers/Dockerfile
@@ -46,7 +46,8 @@ RUN \
         python3-pip \
         python3-dev \
         python-is-python3 \
-        software-properties-common
+        software-properties-common \
+        roz-jazzy-nav2-waypoint-follower
 
 RUN if [ ! -e /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python; fi
 RUN python3 --version


### PR DESCRIPTION
## Problem Description
The current state of code leads to an error during `arena launch` since the `nav2_waypoint_follower` is not found. The commit fixes this error by installing the necessary package.

## Expected Behavior
If the `rviz` window opens when you run `arena launch`, the error has been resolved by this commit.