### PR TITLE
[FIX] Migrating from ros-humble to ros-jazzy

### DIFF
--- a/_meta/repos/arena.repos
+++ b/_meta/repos/arena.repos
@@ -41,26 +41,26 @@ repositories:
   #   url: https://github.com/ros/xacro.git
   #   version: ros2
 
-  deps/nav2/navigation2:
-    type: git
-    url: https://github.com/voshch/navigation2.git
-    version: jazzy
-  deps/nav2/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: ros2
-  deps/nav2/BehaviorTree.CPP:
-    type: git
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: v3.8
-  deps/nav2/diagnostics:
-    type: git
-    url: https://github.com/ros/diagnostics.git
-    version: ros2
-  deps/nav2/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
+  # deps/nav2/navigation2:
+  # type: git
+  # url: https://github.com/voshch/navigation2.git
+  # version: jazzy
+  # deps/nav2/bond_core:
+  # type: git
+  # url: https://github.com/ros/bond_core.git
+  # version: ros2
+  # deps/nav2/BehaviorTree.CPP:
+  # type: git
+  # url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+  # version: v3.8
+  # deps/nav2/diagnostics:
+  # type: git
+  # url: https://github.com/ros/diagnostics.git
+  # version: ros2
+  # deps/nav2/angles:
+  # type: git
+  # url: https://github.com/ros/angles.git
+  # version: ros2
   
   deps/slam_toolbox:
     type: git

--- a/arena_bringup/package.xml
+++ b/arena_bringup/package.xml
@@ -12,6 +12,15 @@
   <depend>nav2_msgs</depend>
   <depend>joint_state_publisher</depend>
   <depend>nav2_map_server</depend>
+  <depend>navigation2</depend>
+  <depend>nav2_bringup</depend>
+  <depend>nav2_waypoint_follower</depend>
+
+  <depend>bondcpp</depend>
+  <depend>behaviortree_cpp_v3</depend>
+  <depend>diagnostics</depend>
+  <depend>angles</depend>
+  <depend>slam_toolbox</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/arena_simulation_setup/configs/nav2/interplanners/empty/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/empty/interplanner_config.yaml
@@ -2,8 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/empty/interplanner_behaviour.xml"
     default_nav_through_poses_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/empty/interplanner_behaviour.xml"
-    plugin_lib_names:
-      - "nav2_compute_path_to_pose_action_bt_node" # minimal configuration for plugin_lib_names
+    plugin_lib_names: [] # minimal configuration for plugin_lib_names
                                                    # has no effect since empty behavior tree is used which does not use any plugins but is used to avoid error
 
       

--- a/arena_simulation_setup/configs/nav2/interplanners/follow_point/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/follow_point/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/follow_point/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/nav_to_pose_with_consistent_replanning_and_if_path_becomes_invalid/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/nav_to_pose_with_consistent_replanning_and_if_path_becomes_invalid/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/nav_to_pose_with_consistent_replanning_and_if_path_becomes_invalid/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_through_poses_w_replanning_and_recovery/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_through_poses_w_replanning_and_recovery/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: ""  
     default_nav_through_poses_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_through_poses_w_replanning_and_recovery/interplanner_behaviour.xml" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_to_pose_w_replanning_and_recovery/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_to_pose_w_replanning_and_recovery/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_to_pose_w_replanning_and_recovery/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_to_pose_w_replanning_goal_patience_and_recovery/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_to_pose_w_replanning_goal_patience_and_recovery/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_to_pose_w_replanning_goal_patience_and_recovery/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_recovery_and_replanning_only_if_path_becomes_invalid/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_recovery_and_replanning_only_if_path_becomes_invalid/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_recovery_and_replanning_only_if_path_becomes_invalid/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_distance/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_distance/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_replanning_distance/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_only_if_goal_is_updated/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_only_if_goal_is_updated/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_replanning_only_if_goal_is_updated/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_only_if_path_becomes_invalid/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_only_if_path_becomes_invalid/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_replanning_only_if_path_becomes_invalid/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_speed/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_speed/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_replanning_speed/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_time/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/navigate_w_replanning_time/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/navigate_w_replanning_time/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/interplanners/odometry_calibration/interplanner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/interplanners/odometry_calibration/interplanner_config.yaml
@@ -2,54 +2,7 @@ bt_navigator:
   ros__parameters:
     default_nav_to_pose_bt_xml: "$(find-pkg-share arena_simulation_setup)/configs/nav2/interplanners/odometry_calibration/interplanner_behaviour.xml"  
     default_nav_through_poses_bt_xml: "" 
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    plugin_lib_names: []
     error_code_names:
       - compute_path_error_code
       - follow_path_error_code

--- a/arena_simulation_setup/configs/nav2/model_params.yaml
+++ b/arena_simulation_setup/configs/nav2/model_params.yaml
@@ -25,7 +25,7 @@ planner_plugins:
   - GridBased
 planner_plugins_dict:
   GridBased:
-    plugin: "nav2_navfn_planner/NavfnPlanner"
+    plugin: "nav2_navfn_planner::NavfnPlanner"
     tolerance: 0.5
     use_astar: false
     allow_unknown: true

--- a/arena_simulation_setup/configs/nav2/nav2.yaml
+++ b/arena_simulation_setup/configs/nav2/nav2.yaml
@@ -55,8 +55,6 @@ bt_navigator:
     
     default_nav_to_pose_bt_xml: ${default_nav_to_pose_bt_xml}
     default_nav_through_poses_bt_xml: ${default_nav_through_poses_bt_xml}
-    
-    plugin_lib_names: ${plugin_lib_names}
 
 bt_navigator_rclcpp_node:
   ros__parameters:

--- a/arena_simulation_setup/configs/nav2/planners/navfn/planner_config.yaml
+++ b/arena_simulation_setup/configs/nav2/planners/navfn/planner_config.yaml
@@ -1,7 +1,7 @@
 planner_plugins_dict:
   planner_plugins: ['GridBased']
   GridBased:
-    plugin: 'nav2_navfn_planner/NavfnPlanner'
+    plugin: 'nav2_navfn_planner::NavfnPlanner'
     use_astar: true
     allow_unknown: true
     tolerance: 0.5

--- a/arena_simulation_setup/package.xml
+++ b/arena_simulation_setup/package.xml
@@ -25,6 +25,7 @@
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>nav2_waypoint_follower</depend>
   
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
There were several changes required in the code to migrate from `humble` to `jazzy`:
- `jazzy` loads all the `nav2` libraries required by Behavior Tree by itself. So we no longer need to load them manually, these will lead to `Exception: ID [some_nav2_library] already registered.`
- The `yaml` files use `::` format instead of `/` now (so `"nav2_navfn_planner/NavfnPlanner"` is now `"nav2_navfn_planner::NavfnPlanner"`)
- There was a version mismatch in the `cv_bridge` library needed to build the `nav2_waypoint_follower`. It was looking for a `.hpp` file but the available version only provided `.h` file. Considering that we no longer need to build the waypoint follower library from source, it was commented out from the `arena.repos` list. Same was done for all `nav2` related repos after discussing this with @voshch. These dependencies were then added to the corresponding `package.xml` files for `rosdep` to resolved.

*Note:* This PR alone shall not solve all the issues. Changes need to be made to the `arena_robots` and `jackal` code too. PRs for these shall follow.