### PR TITLE
Enhancement/map2png objshow

### DIFF
--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
@@ -28,7 +28,7 @@ class Map(PathView):
         rooms: shapely.MultiPolygon,
         doors: shapely.MultiPolygon,
         walls: shapely.MultiLineString,
-        static_objects: list[tuple[str, shapely.Polygon]],
+        static_objects: typing.Optional[typing.List[tuple[str, shapely.Polygon]]] = None,
         resolution: float = 0.01,
         padding: int = 5,
         show_obj_name: bool = True
@@ -73,27 +73,28 @@ class Map(PathView):
             line = tf(shapely.LineString(wall))
             draw.line(as_int(line.coords), fill='black', width=1)
 
-        for name, obj in static_objects:
-            print(name)
-            poly = tf(obj)
-            draw.polygon(as_int(poly.exterior.coords), fill="grey")
-            if show_obj_name:
-                # determine xy to draw object name on
-                coords = poly.exterior.coords
-                _min_x = float('inf')
-                _max_x = float('-inf')
-                _min_y = float('inf')
-                _max_y = float('-inf')
-                for coord in coords:
-                    x = coord[0]
-                    y = coord[1]
-                    print(f"x:{x}, y:{y}")
-                    if _min_x > x: _min_x = x
-                    if _max_x < x: _max_x = x
-                    if _min_y > y: _min_y = y
-                    if _max_y < y: _max_y = y
-                text_draw_pos = [_max_x, _max_y]
-                draw.text(text_draw_pos, name, fill="blue")
+        if static_objects is not None:
+            for name, obj in static_objects:
+                print(name)
+                poly = tf(obj)
+                draw.polygon(as_int(poly.exterior.coords), fill="grey")
+                if show_obj_name:
+                    # determine xy to draw object name on
+                    coords = poly.exterior.coords
+                    _min_x = float('inf')
+                    _max_x = float('-inf')
+                    _min_y = float('inf')
+                    _max_y = float('-inf')
+                    for coord in coords:
+                        x = coord[0]
+                        y = coord[1]
+                        print(f"x:{x}, y:{y}")
+                        if _min_x > x: _min_x = x
+                        if _max_x < x: _max_x = x
+                        if _min_y > y: _min_y = y
+                        if _max_y < y: _max_y = y
+                    text_draw_pos = [_max_x, _max_y]
+                    draw.text(text_draw_pos, name, fill="blue")
 
         img_bytes = io.BytesIO()
         img.save(img_bytes, format='PNG')

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
@@ -28,8 +28,10 @@ class Map(PathView):
         rooms: shapely.MultiPolygon,
         doors: shapely.MultiPolygon,
         walls: shapely.MultiLineString,
+        static_objects: list[tuple[str, shapely.Polygon]],
         resolution: float = 0.01,
         padding: int = 5,
+        show_obj_name: bool = True
     ) -> tuple[bytes, tuple[float, float]]:
         """
         Generate a PNG image of the map with the given elements.
@@ -70,6 +72,28 @@ class Map(PathView):
         for wall in walls.geoms:
             line = tf(shapely.LineString(wall))
             draw.line(as_int(line.coords), fill='black', width=1)
+
+        for name, obj in static_objects:
+            print(name)
+            poly = tf(obj)
+            draw.polygon(as_int(poly.exterior.coords), fill="grey")
+            if show_obj_name:
+                # determine xy to draw object name on
+                coords = poly.exterior.coords
+                _min_x = float('inf')
+                _max_x = float('-inf')
+                _min_y = float('inf')
+                _max_y = float('-inf')
+                for coord in coords:
+                    x = coord[0]
+                    y = coord[1]
+                    print(f"x:{x}, y:{y}")
+                    if _min_x > x: _min_x = x
+                    if _max_x < x: _max_x = x
+                    if _min_y > y: _min_y = y
+                    if _max_y < y: _max_y = y
+                text_draw_pos = [_max_x, _max_y]
+                draw.text(text_draw_pos, name, fill="blue")
 
         img_bytes = io.BytesIO()
         img.save(img_bytes, format='PNG')

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/Map.py
@@ -31,10 +31,23 @@ class Map(PathView):
         static_objects: typing.Optional[typing.List[tuple[str, shapely.Polygon]]] = None,
         resolution: float = 0.01,
         padding: int = 5,
-        show_obj_name: bool = True
+        show_obj_name: bool = True,
+        asset_color: str = "grey",
+        asset_name_color: str = "blue"
     ) -> tuple[bytes, tuple[float, float]]:
         """
         Generate a PNG image of the map with the given elements.
+        
+        Args:
+            rooms (shapely.MultiPolygon): MultiPolygon representing the rooms in the map.
+            doors (shapely.MultiPolygon): MultiPolygon representing the doors in the map.
+            walls (shapely.MultiLineString): MultiLineString representing the walls in the map.
+            static_objects (Optional[List[Tuple[str, shapely.Polygon]]]): Optional list of (name, Polygon) tuples for static objects to draw.
+            resolution (float): Size of each pixel in meters.
+            padding (int): Number of pixels to pad around the map.
+            show_obj_name (bool): Whether to display object names on the map.
+            asset_color (str): Color used to fill static objects.
+            asset_name_color (str): Color used for static object names.
         """
         min_x, min_y, max_x, max_y = rooms.bounds
 
@@ -77,7 +90,7 @@ class Map(PathView):
             for name, obj in static_objects:
                 print(name)
                 poly = tf(obj)
-                draw.polygon(as_int(poly.exterior.coords), fill="grey")
+                draw.polygon(as_int(poly.exterior.coords), fill=asset_color)
                 if show_obj_name:
                     # determine xy to draw object name on
                     coords = poly.exterior.coords
@@ -94,7 +107,7 @@ class Map(PathView):
                         if _min_y > y: _min_y = y
                         if _max_y < y: _max_y = y
                     text_draw_pos = [_max_x, _max_y]
-                    draw.text(text_draw_pos, name, fill="blue")
+                    draw.text(text_draw_pos, name, fill=asset_name_color)
 
         img_bytes = io.BytesIO()
         img.save(img_bytes, format='PNG')

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
@@ -177,7 +177,8 @@ class WorldDescription:
                         [-width / 2, -height / 2],
                         [ width / 2, -height / 2],
                         [ width / 2,  height / 2],
-                        [-width / 2,  height / 2]
+                        [-width / 2,  height / 2],
+                        [-width / 2, -height / 2]
                     ] 
                     (center_x, center_y, yaw) = entity.pose.to_2d()
                     tf = lambda x,y: [math.cos(yaw)*x - math.sin(yaw)*y, math.sin(yaw)*x + math.cos(yaw)*y]

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
@@ -2,6 +2,7 @@ import io
 import os
 import tarfile
 import typing
+from typing import Optional, List
 from pathlib import Path
 
 import attrs
@@ -100,46 +101,91 @@ class WorldDescription:
     def render(
         self,
         resolution: float = 0.05,
+        asset_default_bbox: Optional[List[List[float]]] = None,
+        asset_color: Optional[str] = None,
     ) -> typing.Tuple[bytes, tuple[float, float]]:
-        """Render the world description to a PNG image
+        """
+        Render the world description to a PNG image.
 
         Args:
-            resolution (float): The resolution of the rendered image [m/px]
+            resolution (float): The resolution of the rendered image in meters per pixel.
+            asset_default_bbox (Optional[List[List[float]]]): Default bounding box [[xmin, xmax], [ymin, ymax], [zmin, zmax]] to use for static entities if not specified individually.
+            asset_color (Optional[str]): Color used to fill static objects in the map.
 
         Returns:
-            typing.Tuple[bytes, tuple[float, float]]: The rendered image and its origin
+            Tuple[bytes, tuple[float, float]]: PNG image bytes and the origin (x, y) of the map.
+
+        Notes:
+            - Static objects are drawn only if their dimensions can be determined from bbox, width/height, or asset_default_bbox.
+            - If asset_color is None, static objects are not drawn.
         """
         import shapely
         import math
 
-        staticObjects: list[tuple[str, shapely.Polygon]] = []
-        default_width = 0.5
-        default_height = 0.5
-        for entity in self.all_static_entities:
-            # get the corners for entity
+        if asset_color is not None:
+            staticObjects: list[tuple[str, shapely.Polygon]] = []
+            for entity in self.all_static_entities:
+                # get the corners for entity
+                # dimension is determined with the following priority:
+                # 1. bbox given as an extra property for entity
+                # 2. width and height as extra properties for entity (both have to be set for consistency)
+                # 3. asset_default_bbox
+                # if none of these is set, asset will not be drawn
 
-            # if dimension is given as extra property, use it
-            _width = entity.asdict(expand_extra=True).get("width")
-            _height = entity.asdict(expand_extra=True).get("height")
-            width = default_width
-            height = default_height
-            if _width is not None:
-                width = _width
-            if _height is not None:
-                height = _height
+                def validate_bbox(bbox):
+                    if not isinstance(bbox, (list, tuple)):
+                        return False
+                    if len(bbox) != 2 or len(bbox) != 3:
+                        return False
+                    for axis in bbox:
+                        if not isinstance(axis, (list, tuple)):
+                            return False
+                        if len(axis) != 2:
+                            return False
+                        for value in axis:
+                            if not isinstance(value, (int, float)):
+                                return False
+                    return True
 
-            # corners before transformation
-            _corners_center_origin= [
-                [-width / 2, -height / 2],
-                [ width / 2, -height / 2],
-                [ width / 2,  height / 2],
-                [-width / 2,  height / 2]
-            ] 
-            (center_x, center_y, yaw) = entity.pose.to_2d()
-            tf = lambda x,y: [math.cos(yaw)*x - math.sin(yaw)*y, math.sin(yaw)*x + math.cos(yaw)*y]
-            corners_center_origin = [tf(x,y) for [x,y] in _corners_center_origin]
-            corners = [[center_x+x, center_y+y] for [x,y] in corners_center_origin]
-            staticObjects.append((entity.name, shapely.Polygon(corners)))
+                bbox_key_candidates = ["bbox", "boundingBox", "bounding_box"]
+                import math
+                width = float("NaN")
+                height = float("NaN")
+                dim_undetermined = lambda : math.isnan(width) or math.isnan(height)
+                for key in bbox_key_candidates:
+                    val = entity.asdict(expand_extra=True).get(key)
+                    if val is not None and validate_bbox(val):
+                        width = val[0][1] - val[0][0]
+                        height = val[1][1] - val[1][0]
+                        break
+                if dim_undetermined():
+                    val = entity.asdict(expand_extra=True).get("width")
+                    if val is not None and isinstance(val, (float, int)):
+                        width = val
+                    val = entity.asdict(expand_extra=True).get("height")
+                    if val is not None and isinstance(val, (float, int)):
+                        height = val
+                if dim_undetermined() and asset_default_bbox is not None and validate_bbox(asset_default_bbox):
+                        width = asset_default_bbox[0][1] - asset_default_bbox[0][0]
+                        height = asset_default_bbox[1][1] - asset_default_bbox[1][0]
+                
+                if dim_undetermined():
+                    continue # if width and height could not be determined, skip for this asset
+                else:
+                    # corners before transformation
+                    _corners_center_origin= [
+                        [-width / 2, -height / 2],
+                        [ width / 2, -height / 2],
+                        [ width / 2,  height / 2],
+                        [-width / 2,  height / 2]
+                    ] 
+                    (center_x, center_y, yaw) = entity.pose.to_2d()
+                    tf = lambda x,y: [math.cos(yaw)*x - math.sin(yaw)*y, math.sin(yaw)*x + math.cos(yaw)*y]
+                    corners_center_origin = [tf(x,y) for [x,y] in _corners_center_origin]
+                    corners = [[center_x+x, center_y+y] for [x,y] in corners_center_origin]
+                    staticObjects.append((entity.name, shapely.Polygon(corners)))
+        else:
+            staticObjects = None
 
         png, origin = Map.generate_png(
             rooms=shapely.MultiPolygon([shapely.Polygon(zone.corners) for zone in self.zones]),
@@ -148,7 +194,8 @@ class WorldDescription:
             static_objects=staticObjects,
             resolution=resolution,
             padding=5,
-            show_obj_name=False
+            show_obj_name=False,
+            asset_color=asset_color
         )
         return png, origin
 
@@ -156,6 +203,7 @@ class WorldDescription:
         self,
         resolution: float = 0.05,
         extra_files: dict[str, bytes] | None = None,
+        **kwargs
     ) -> tarfile.TarFile:
         """
         Export the world description to world.yaml, map.png, map.yaml
@@ -167,7 +215,13 @@ class WorldDescription:
 
         files['world.yaml'] = typing.cast(bytes, yaml.safe_dump(converter.unstructure(self), encoding='utf-8', sort_keys=False))
 
-        files['map/map.png'], origin = self.render(resolution=resolution)
+        render_args = {"resolution": resolution}
+        if "asset_default_bbox" in kwargs:
+            render_args["asset_default_bbox"] = kwargs["asset_default_bbox"]
+        if "asset_color" in kwargs:
+            render_args["asset_color"] = kwargs["asset_color"]
+
+        files['map/map.png'], origin = self.render(**render_args)
 
         files['map/map.yaml'] = Map.generate_map_yaml(resolution=resolution, filename='map.png', origin=origin).encode('utf-8')
 

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
@@ -101,7 +101,7 @@ class WorldDescription:
     def render(
         self,
         resolution: float = 0.05,
-        asset_default_bbox: Optional[List[List[float]]] = None,
+        default_asset_bbox: Optional[List[List[float]]] = None,
         asset_color: Optional[str] = None,
     ) -> typing.Tuple[bytes, tuple[float, float]]:
         """
@@ -109,14 +109,14 @@ class WorldDescription:
 
         Args:
             resolution (float): The resolution of the rendered image in meters per pixel.
-            asset_default_bbox (Optional[List[List[float]]]): Default bounding box [[xmin, xmax], [ymin, ymax], [zmin, zmax]] to use for static entities if not specified individually.
+            default_asset_bbox (Optional[List[List[float]]]): Default bounding box [[xmin, xmax], [ymin, ymax], [zmin, zmax]] to use for static entities if not specified individually.
             asset_color (Optional[str]): Color used to fill static objects in the map.
 
         Returns:
             Tuple[bytes, tuple[float, float]]: PNG image bytes and the origin (x, y) of the map.
 
         Notes:
-            - Static objects are drawn only if their dimensions can be determined from bbox, width/height, or asset_default_bbox.
+            - Static objects are drawn only if their dimensions can be determined from bbox, width/height, or default_asset_bbox.
             - If asset_color is None, static objects are not drawn.
         """
         import shapely
@@ -129,13 +129,13 @@ class WorldDescription:
                 # dimension is determined with the following priority:
                 # 1. bbox given as an extra property for entity
                 # 2. width and height as extra properties for entity (both have to be set for consistency)
-                # 3. asset_default_bbox
+                # 3. default_asset_bbox
                 # if none of these is set, asset will not be drawn
 
                 def validate_bbox(bbox):
                     if not isinstance(bbox, (list, tuple)):
                         return False
-                    if len(bbox) != 2 or len(bbox) != 3:
+                    if len(bbox) != 2 and len(bbox) != 3:
                         return False
                     for axis in bbox:
                         if not isinstance(axis, (list, tuple)):
@@ -165,9 +165,9 @@ class WorldDescription:
                     val = entity.asdict(expand_extra=True).get("height")
                     if val is not None and isinstance(val, (float, int)):
                         height = val
-                if dim_undetermined() and asset_default_bbox is not None and validate_bbox(asset_default_bbox):
-                        width = asset_default_bbox[0][1] - asset_default_bbox[0][0]
-                        height = asset_default_bbox[1][1] - asset_default_bbox[1][0]
+                if dim_undetermined() and default_asset_bbox is not None and validate_bbox(default_asset_bbox):
+                        width = default_asset_bbox[0][1] - default_asset_bbox[0][0]
+                        height = default_asset_bbox[1][1] - default_asset_bbox[1][0]
                 
                 if dim_undetermined():
                     continue # if width and height could not be determined, skip for this asset
@@ -216,8 +216,8 @@ class WorldDescription:
         files['world.yaml'] = typing.cast(bytes, yaml.safe_dump(converter.unstructure(self), encoding='utf-8', sort_keys=False))
 
         render_args = {"resolution": resolution}
-        if "asset_default_bbox" in kwargs:
-            render_args["asset_default_bbox"] = kwargs["asset_default_bbox"]
+        if "default_asset_bbox" in kwargs:
+            render_args["default_asset_bbox"] = kwargs["default_asset_bbox"]
         if "asset_color" in kwargs:
             render_args["asset_color"] = kwargs["asset_color"]
 

--- a/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
+++ b/arena_simulation_setup/src/arena_simulation_setup/tree/World/World.py
@@ -110,13 +110,45 @@ class WorldDescription:
             typing.Tuple[bytes, tuple[float, float]]: The rendered image and its origin
         """
         import shapely
+        import math
+
+        staticObjects: list[tuple[str, shapely.Polygon]] = []
+        default_width = 0.5
+        default_height = 0.5
+        for entity in self.all_static_entities:
+            # get the corners for entity
+
+            # if dimension is given as extra property, use it
+            _width = entity.asdict(expand_extra=True).get("width")
+            _height = entity.asdict(expand_extra=True).get("height")
+            width = default_width
+            height = default_height
+            if _width is not None:
+                width = _width
+            if _height is not None:
+                height = _height
+
+            # corners before transformation
+            _corners_center_origin= [
+                [-width / 2, -height / 2],
+                [ width / 2, -height / 2],
+                [ width / 2,  height / 2],
+                [-width / 2,  height / 2]
+            ] 
+            (center_x, center_y, yaw) = entity.pose.to_2d()
+            tf = lambda x,y: [math.cos(yaw)*x - math.sin(yaw)*y, math.sin(yaw)*x + math.cos(yaw)*y]
+            corners_center_origin = [tf(x,y) for [x,y] in _corners_center_origin]
+            corners = [[center_x+x, center_y+y] for [x,y] in corners_center_origin]
+            staticObjects.append((entity.name, shapely.Polygon(corners)))
 
         png, origin = Map.generate_png(
             rooms=shapely.MultiPolygon([shapely.Polygon(zone.corners) for zone in self.zones]),
             doors=shapely.MultiPolygon([shapely.Polygon(door.corners) for door in self.all_doors]),
             walls=shapely.MultiLineString(list(self.all_walls)),
+            static_objects=staticObjects,
             resolution=resolution,
             padding=5,
+            show_obj_name=False
         )
         return png, origin
 


### PR DESCRIPTION
# Overview
added static object bounding boxes to .png export from Map
# Changes
- `Wall` class `generate_png`: 
changed so that it will take optional arguments for tuple of object name and shapely polygon to draw grey rect on entity position
- `WorldDescription` class `render`
 modified to work with the new generate_png method

# rendered image example
exported from AIrchitect app
<img width="290" height="130" alt="map" src="https://github.com/user-attachments/assets/9a6150db-cfdd-4750-88f8-24d16599b7f8" />
