### PR TITLE
fix: resolve task_generator_node crash by adding CycloneDDS dependency

### DIFF
--- a/_meta/docker/docker-compose.yaml
+++ b/_meta/docker/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - HOST_GID
       - HOST_ARENA_WS_DIR
       - LLM_API_ENDPOINT
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     env_file:
       - "$HOST_ARENA_WS_DIR/.env"
     user: "${HOST_UID}"

--- a/_meta/docker/features/docker/Dockerfile
+++ b/_meta/docker/features/docker/Dockerfile
@@ -15,7 +15,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pipx \
     python3-colcon-common-extensions \
     python3-rosdep \
-    sudo
+    sudo \
+    ros-jazzy-rmw-cyclonedds-cpp
 
 RUN pipx install git+https://github.com/voshch/vcstool.git
 


### PR DESCRIPTION
Resolves an `exit code 127` crash in the `task_generator_node` caused by missing dependencies in the container environment.

`[ERROR] [task_generator_node-6]: process has died [pid 27076, exit code 127, cmd '/opt/arena_ws/install/task_generator/lib/task_generator/task_generator_node --ros-args -r node:=task_generator_node -r ns:=/ --params-file /tmp/shared/launch_params_7dfhqxjg --params-file /tmp/shared/launch_params_7eyerglx --params-file /opt/arena_ws/install/arena_bringup/share/arena_bringup/configs/task_generator.yaml --log-level warn']`